### PR TITLE
raven: silence "Ranch listener" reports and lager messages originally from error_logger

### DIFF
--- a/src/raven_error_logger.erl
+++ b/src/raven_error_logger.erl
@@ -22,7 +22,7 @@ handle_event({error, _, {Pid, Format, Data}}, State) ->
 	raven:capture(Message, Details),
 	{ok, State};
 handle_event({error_report, _, {Pid, Type, Report}}, State) ->
-	{Message, Details} = parse_report(error, Pid, Type, lists:sort(Report)),
+	{Message, Details} = parse_report(error, Pid, Type, Report),
 	raven:capture(Message, Details),
 	{ok, State};
 

--- a/src/raven_lager_backend.erl
+++ b/src/raven_lager_backend.erl
@@ -39,8 +39,7 @@ handle_event({log, Data},
     #state{level=L} = State) ->
     case lager_util:is_loggable(Data, L, ?MODULE) of
         true ->
-            {Message, Params} = parse_message(Data),
-            raven:capture(Message, Params),
+            capture(parse_message(Data)),
             {ok, State};
         false ->
             {ok, State}
@@ -58,15 +57,29 @@ code_change(_, State, _) ->
 terminate(_, _) ->
 	ok.
 
+capture(mask) ->
+    ok;
+capture({Message, Params}) ->
+    raven:capture(Message, Params).
 
 %% TODO - check what other metadata can be sent to sentry
 parse_message({lager_msg, [], MetaData, Level, _, _Time, Message}) ->
-    Extra = parse_meta(MetaData),
-    {Message, [{level, Level},
-               {extra, Extra}]}.
+    case parse_meta(MetaData) of
+        mask ->
+            mask;
+        Extra ->
+            {Message, [{level, Level},
+                       {extra, Extra}]}
+    end.
 
 
-%% @doc at the moment this is just a passthrough -- what other metadata is out there?
+%% @doc Extracts pid from lager message metadata. Lager messages that came
+%% from error_logger are flagged as such in the metadata, in which case we
+%% immediately return 'mask', indicating that the message should be skipped.
+%% This assumes that raven's error_logger handler is installed, to avoid
+%% double-capturing error_logger events.
+%% TODO: respect default_error_logger config, instead of assuming it is set
+%% to true.
 parse_meta(MetaData) ->
     parse_meta(MetaData, []).
 
@@ -74,6 +87,8 @@ parse_meta([], Acc) ->
     Acc;
 parse_meta([{pid, Pid} = PidProp | Rest], Acc) when is_pid(Pid) ->
     parse_meta(Rest, [PidProp | Acc]);
+parse_meta([{error_logger, _} | _Rest], _Acc) ->
+    mask;
 parse_meta([{_, _} | Rest], Acc) ->
     parse_meta(Rest, Acc).
 


### PR DESCRIPTION
Two parts:
1) Ignore any error report beginning with "Ranch listener". ranch (used internally by cowboy) manually submits reports to error_logger (https://github.com/ninenines/ranch/blob/master/src/ranch_conns_sup.erl#L268-L272), which is redundant with error logging that happens internally by the VM for procs started with the spawn BIF and the error logging done by proc_lib in its own spawn function.
2) Ignore any message from lager that is marked as originating in the error_logger. This is because raven also listens for error_logger events, so we don't want to process them twice, once after lager has massaged them. See https://github.com/ptuckey/lager/pull/1 .